### PR TITLE
removed eo-runtime dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,11 +92,6 @@ SOFTWARE
   </distributionManagement>
   <dependencies>
     <dependency>
-      <groupId>org.eolang</groupId>
-      <artifactId>eo-runtime</artifactId>
-      <version>0.28.10</version>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.9.1</version>


### PR DESCRIPTION
Related to #80.

We don't need `eo-runtime` anymore in our pom.xml file